### PR TITLE
remove Period Handling

### DIFF
--- a/doc/source/control/const_profile.rst
+++ b/doc/source/control/const_profile.rst
@@ -18,13 +18,3 @@ The controller can write the values to the any input of a controller in the same
 
 .. autoclass:: pandaprosumer.controller.const_profile.ConstProfileController
     :members:
-
-Period Handling
-================
-
-A period needs to be defined to use the `ConstProfileController`.
-
-If no period is explicitly set for the controller, it will try to detect a `period` column in the DataFrame provided by the DataSource.
-If this column exists, a default period will automatically be created and used.
-
-If neither a period is defined nor a `period` column is present in the DataFrame, an error will be raised.


### PR DESCRIPTION
The _Period Handling_ feature is not yet included in the opensource pandaprosumer, a new PR will be made soon but in the meantime it should not be documented